### PR TITLE
close #22

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,10 +36,11 @@ Imports:
     RCurl (>= 1.98-1.2), 
     rlang (>= 0.4.6),
     stringr (>= 1.4.0),
+    tibble (>= 3.0.1),
     tidyr (>= 1.1.0),
     viridis (>= 0.5.1),
     XML (>= 3.99-0.3)
-    tibble (>= 3.0.1)
+    
 RoxygenNote: 6.1.1
 Depends:
     R (>= 3.5)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     tidyr (>= 1.1.0),
     viridis (>= 0.5.1),
     XML (>= 3.99-0.3)
+    tibble (>= 3.0.1)
 RoxygenNote: 6.1.1
 Depends:
     R (>= 3.5)

--- a/R/download.R
+++ b/R/download.R
@@ -85,7 +85,7 @@ create_storm_data <- function(date_range = NULL, storm = NULL,
     stop("You must specify either `date_range` or `storm`.")
   }
 
-  storm_data <- dplyr::tbl_df(storm_data)
-
+  #storm_data <- dplyr::tbl_df(storm_data)
+storm_data <- tibble::as_tibble(storm_data)
   return(storm_data)
 }

--- a/R/download.R
+++ b/R/download.R
@@ -85,7 +85,6 @@ create_storm_data <- function(date_range = NULL, storm = NULL,
     stop("You must specify either `date_range` or `storm`.")
   }
 
-  #storm_data <- dplyr::tbl_df(storm_data)
-storm_data <- tibble::as_tibble(storm_data)
+  storm_data <- tibble::as_tibble(storm_data)
   return(storm_data)
 }


### PR DESCRIPTION
changed ```tbl_df()``` to ```tibble::as_tibble()``` in download.R to fix find_events warning message and added tibble to the imports list in the package description